### PR TITLE
chore: Prevent search engine indexing for prototype site

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Ocobo | Architecture RevOps</title>
-    <meta name="description" content="Ocobo - Nous transformons la croissance en expérience simple, fluide et pilotable." />
+
+    <!-- Prevent Search Engine Indexing - Prototype Site -->
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="googlebot" content="noindex, nofollow" />
+    <meta name="bingbot" content="noindex, nofollow" />
+
+    <title>Ocobo | Architecture RevOps [PROTOTYPE]</title>
+    <meta name="description" content="[PROTOTYPE - DO NOT INDEX] Internal development prototype - not for public access." />
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+# Prototype Site - Block All Search Engine Crawlers
+# This site should NOT be indexed by search engines
+
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Add robots.txt and update index.html meta tags to block
search engine crawlers and clearly mark the site as a
prototype. Ensures no accidental indexing of development
or staging environments.