### PR TITLE
refactor: migrate studio sections to Panda CSS

### DIFF
--- a/components/sections/home/InterventionsSection.tsx
+++ b/components/sections/home/InterventionsSection.tsx
@@ -5,6 +5,119 @@ import { Button } from '../../atoms/Button';
 import { Container } from '../../organisms/Container';
 import { Section } from '../../organisms/Section';
 
+// new section from the studio
+
+import { ArrowRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const _NewInterventionsSection = () => {
+	return (
+		<section className="py-24 bg-white">
+			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+				<h2 className="font-display text-4xl font-bold text-ocobo-dark mb-4 text-center">
+					Nos interventions
+				</h2>
+				<p className="text-center text-gray-600 max-w-2xl mx-auto mb-20">
+					Nous vous aidons à construire les fondations RevOps dont dépend votre
+					croissance.
+				</p>
+
+				<div className="grid md:grid-cols-3 gap-8 md:gap-10">
+					{/* DESIGN */}
+					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
+						<div className="mb-8">
+							<span className="inline-block bg-ocobo-yellow text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+								DESIGN
+							</span>
+							<p className="text-[10px] font-black text-ocobo-yellow uppercase tracking-widest mt-3 ml-1 opacity-70">
+								L'architecture
+							</p>
+						</div>
+						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
+							Immersion, diagnostic et plan d’action RevOps
+						</h3>
+						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
+							Ne construisez pas à l'aveugle. Nous auditons votre GTM (équipes,
+							systèmes, données) et livrons la roadmap précise (Budget &
+							Planning) pour sécuriser l'année.
+						</p>
+
+						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-yellow opacity-0 group-hover:opacity-100 transition-opacity">
+							<span className="text-[10px] font-bold uppercase tracking-widest">
+								Voir le détail
+							</span>
+							<ArrowRight size={16} />
+						</div>
+					</div>
+
+					{/* OPERATE */}
+					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
+						<div className="mb-8">
+							<span className="inline-block bg-ocobo-sky text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+								OPERATE
+							</span>
+							<p className="text-[10px] font-black text-ocobo-sky uppercase tracking-widest mt-3 ml-1 opacity-70">
+								La construction
+							</p>
+						</div>
+						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
+							La phase de transformation intensive.
+						</h3>
+						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
+							Une Squad complète déploie votre infrastructure en sprints de 2
+							semaines. On priorise, on construit, on teste, on livre.
+						</p>
+
+						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-sky opacity-0 group-hover:opacity-100 transition-opacity">
+							<span className="text-[10px] font-bold uppercase tracking-widest">
+								Voir le détail
+							</span>
+							<ArrowRight size={16} />
+						</div>
+					</div>
+
+					{/* GROW */}
+					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
+						<div className="mb-8">
+							<span className="inline-block bg-ocobo-mint text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+								GROW
+							</span>
+							<p className="text-[10px] font-black text-ocobo-mint uppercase tracking-widest mt-3 ml-1 opacity-70">
+								La croissance
+							</p>
+						</div>
+						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
+							Le passage de témoin vers la performance durable.
+						</h3>
+						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
+							Nous pilotons votre "Run" au quotidien pour maximiser le ROI et
+							récolter les fruits du travail accompli.
+						</p>
+
+						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-mint opacity-0 group-hover:opacity-100 transition-opacity">
+							<span className="text-[10px] font-bold uppercase tracking-widest">
+								Voir le détail
+							</span>
+							<ArrowRight size={16} />
+						</div>
+					</div>
+				</div>
+
+				<div className="flex justify-center mt-20">
+					<Link to="/offer">
+						<Button
+							variant="outline"
+							className="px-12 py-4 text-xs font-black uppercase tracking-widest border-2"
+						>
+							Voir toutes nos interventions
+						</Button>
+					</Link>
+				</div>
+			</div>
+		</section>
+	);
+};
+
 const INTERVENTIONS = [
 	{
 		number: 1,

--- a/components/sections/home/InterventionsSection.tsx
+++ b/components/sections/home/InterventionsSection.tsx
@@ -1,141 +1,73 @@
+import { ArrowRight } from 'lucide-react';
 import type React from 'react';
 import { css } from 'styled-system/css';
-import { center, flex, grid } from 'styled-system/patterns';
+import { flex, grid } from 'styled-system/patterns';
+import { Badge } from '../../atoms/Badge';
 import { Button } from '../../atoms/Button';
 import { Container } from '../../organisms/Container';
 import { Section } from '../../organisms/Section';
 
-// new section from the studio
+type InterventionColor = 'yellow' | 'sky' | 'mint';
 
-import { ArrowRight } from 'lucide-react';
-import { Link } from 'react-router-dom';
+interface Intervention {
+	badge: string;
+	badgeColor: InterventionColor;
+	subtitle: string;
+	title: string;
+	description: string;
+}
 
-const _NewInterventionsSection = () => {
-	return (
-		<section className="py-24 bg-white">
-			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-				<h2 className="font-display text-4xl font-bold text-ocobo-dark mb-4 text-center">
-					Nos interventions
-				</h2>
-				<p className="text-center text-gray-600 max-w-2xl mx-auto mb-20">
-					Nous vous aidons à construire les fondations RevOps dont dépend votre
-					croissance.
-				</p>
-
-				<div className="grid md:grid-cols-3 gap-8 md:gap-10">
-					{/* DESIGN */}
-					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
-						<div className="mb-8">
-							<span className="inline-block bg-ocobo-yellow text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-								DESIGN
-							</span>
-							<p className="text-[10px] font-black text-ocobo-yellow uppercase tracking-widest mt-3 ml-1 opacity-70">
-								L'architecture
-							</p>
-						</div>
-						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
-							Immersion, diagnostic et plan d’action RevOps
-						</h3>
-						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
-							Ne construisez pas à l'aveugle. Nous auditons votre GTM (équipes,
-							systèmes, données) et livrons la roadmap précise (Budget &
-							Planning) pour sécuriser l'année.
-						</p>
-
-						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-yellow opacity-0 group-hover:opacity-100 transition-opacity">
-							<span className="text-[10px] font-bold uppercase tracking-widest">
-								Voir le détail
-							</span>
-							<ArrowRight size={16} />
-						</div>
-					</div>
-
-					{/* OPERATE */}
-					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
-						<div className="mb-8">
-							<span className="inline-block bg-ocobo-sky text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-								OPERATE
-							</span>
-							<p className="text-[10px] font-black text-ocobo-sky uppercase tracking-widest mt-3 ml-1 opacity-70">
-								La construction
-							</p>
-						</div>
-						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
-							La phase de transformation intensive.
-						</h3>
-						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
-							Une Squad complète déploie votre infrastructure en sprints de 2
-							semaines. On priorise, on construit, on teste, on livre.
-						</p>
-
-						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-sky opacity-0 group-hover:opacity-100 transition-opacity">
-							<span className="text-[10px] font-bold uppercase tracking-widest">
-								Voir le détail
-							</span>
-							<ArrowRight size={16} />
-						</div>
-					</div>
-
-					{/* GROW */}
-					<div className="bg-white border border-gray-100 p-10 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 group flex flex-col h-full rounded-2xl relative overflow-hidden">
-						<div className="mb-8">
-							<span className="inline-block bg-ocobo-mint text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-								GROW
-							</span>
-							<p className="text-[10px] font-black text-ocobo-mint uppercase tracking-widest mt-3 ml-1 opacity-70">
-								La croissance
-							</p>
-						</div>
-						<h3 className="font-display text-2xl font-bold mb-6 text-ocobo-dark group-hover:text-black transition-colors leading-tight">
-							Le passage de témoin vers la performance durable.
-						</h3>
-						<p className="text-gray-600 text-sm leading-relaxed flex-grow font-medium">
-							Nous pilotons votre "Run" au quotidien pour maximiser le ROI et
-							récolter les fruits du travail accompli.
-						</p>
-
-						<div className="mt-10 pt-6 border-t border-gray-50 flex items-center justify-between text-ocobo-mint opacity-0 group-hover:opacity-100 transition-opacity">
-							<span className="text-[10px] font-bold uppercase tracking-widest">
-								Voir le détail
-							</span>
-							<ArrowRight size={16} />
-						</div>
-					</div>
-				</div>
-
-				<div className="flex justify-center mt-20">
-					<Link to="/offer">
-						<Button
-							variant="outline"
-							className="px-12 py-4 text-xs font-black uppercase tracking-widest border-2"
-						>
-							Voir toutes nos interventions
-						</Button>
-					</Link>
-				</div>
-			</div>
-		</section>
-	);
-};
-
-const INTERVENTIONS = [
+const INTERVENTIONS: Intervention[] = [
 	{
-		number: 1,
+		badge: 'DESIGN',
+		badgeColor: 'yellow',
+		subtitle: "L'architecture",
 		title: "Immersion, diagnostic et plan d'action RevOps",
-		description: 'Pour voir clair et savoir quoi faire. Dans cet ordre là.',
-	},
-	{
-		number: 2,
-		title: 'Déploiement RevOps (Agile)',
 		description:
-			'Pour (re)construire et opérer votre machine revenue en sprints de 2 semaines.',
+			"Ne construisez pas à l'aveugle. Nous auditons votre GTM (équipes, systèmes, données) et livrons la roadmap précise (Budget & Planning) pour sécuriser l'année.",
 	},
 	{
-		number: 3,
-		title: 'Formation & Coaching',
-		description: 'Pour rendre vos équipes autonomes et pérennes.',
+		badge: 'OPERATE',
+		badgeColor: 'sky',
+		subtitle: 'La construction',
+		title: 'La phase de transformation intensive.',
+		description:
+			'Une Squad complète déploie votre infrastructure en sprints de 2 semaines. On priorise, on construit, on teste, on livre.',
+	},
+	{
+		badge: 'GROW',
+		badgeColor: 'mint',
+		subtitle: 'La croissance',
+		title: 'Le passage de témoin vers la performance durable.',
+		description:
+			'Nous pilotons votre "Run" au quotidien pour maximiser le ROI et récolter les fruits du travail accompli.',
 	},
 ];
+
+const COLOR_MAP: Record<InterventionColor, string> = {
+	yellow: 'ocobo.yellow',
+	sky: 'ocobo.sky',
+	mint: 'ocobo.mint',
+} as const;
+
+const cardStyle = css({
+	bg: 'white',
+	borderWidth: '1px',
+	borderColor: 'gray.100',
+	p: '10',
+	rounded: '2xl',
+	display: 'flex',
+	flexDirection: 'column',
+	h: 'full',
+	position: 'relative',
+	overflow: 'hidden',
+	transition: 'all',
+	transitionDuration: '300ms',
+	_hover: {
+		shadow: '2xl',
+		translateY: '-1',
+	},
+});
 
 export const InterventionsSection: React.FC = () => {
 	return (
@@ -159,57 +91,104 @@ export const InterventionsSection: React.FC = () => {
 						color: 'gray.600',
 						maxW: '2xl',
 						mx: 'auto',
-						mb: '16',
+						mb: '20',
 					})}
 				>
 					Nous vous aidons à construire les fondations RevOps dont dépend votre
 					croissance.
 				</p>
 
-				<div className={grid({ columns: { base: 1, md: 3 }, gap: '8' })}>
-					{INTERVENTIONS.map((intervention) => (
-						<div
-							key={intervention.number}
-							className={css({
-								bg: 'white',
-								borderWidth: '1px',
-								borderColor: 'gray.200',
-								p: '8',
-								transition: 'colors',
-								_hover: { borderColor: 'ocobo.dark' },
-							})}
-						>
-							<div
-								className={`${center()} ${css({
-									w: '12',
-									h: '12',
-									bg: 'ocobo.dark',
-									color: 'white',
-									mb: '6',
-								})}`}
-							>
-								{intervention.number}
+				<div
+					className={grid({
+						columns: { base: 1, md: 3 },
+						gap: { base: '8', md: '10' },
+					})}
+				>
+					{INTERVENTIONS.map((item) => {
+						const color = COLOR_MAP[item.badgeColor];
+						return (
+							<div key={item.badge} className={`group ${cardStyle}`}>
+								<div className={css({ mb: '8' })}>
+									<Badge variant={item.badgeColor} rounded="full">
+										{item.badge}
+									</Badge>
+									<p
+										className={css({
+											fontSize: '2xs',
+											fontWeight: 'black',
+											textTransform: 'uppercase',
+											letterSpacing: 'widest',
+											mt: '3',
+											ml: '1',
+											opacity: '0.7',
+											color,
+										})}
+									>
+										{item.subtitle}
+									</p>
+								</div>
+								<h3
+									className={css({
+										fontFamily: 'display',
+										fontSize: '2xl',
+										fontWeight: 'bold',
+										mb: '6',
+										color: 'ocobo.dark',
+										lineHeight: 'tight',
+										transition: 'colors',
+										_groupHover: { color: 'black' },
+									})}
+								>
+									{item.title}
+								</h3>
+								<p
+									className={css({
+										color: 'gray.600',
+										fontSize: 'sm',
+										lineHeight: 'relaxed',
+										flex: '1',
+										fontWeight: 'medium',
+									})}
+								>
+									{item.description}
+								</p>
+
+								<div
+									className={css({
+										mt: '10',
+										pt: '6',
+										borderTopWidth: '1px',
+										borderTopColor: 'gray.50',
+										display: 'flex',
+										alignItems: 'center',
+										justifyContent: 'space-between',
+										color,
+										opacity: '0',
+										transition: 'opacity',
+										transitionDuration: '300ms',
+										_groupHover: { opacity: '1' },
+									})}
+								>
+									<span
+										className={css({
+											fontSize: '2xs',
+											fontWeight: 'bold',
+											textTransform: 'uppercase',
+											letterSpacing: 'widest',
+										})}
+									>
+										Voir le détail
+									</span>
+									<ArrowRight size={16} />
+								</div>
 							</div>
-							<h3
-								className={css({
-									fontFamily: 'display',
-									fontSize: 'xl',
-									fontWeight: 'bold',
-									mb: '4',
-								})}
-							>
-								{intervention.title}
-							</h3>
-							<p className={css({ color: 'gray.600', fontSize: 'sm' })}>
-								{intervention.description}
-							</p>
-						</div>
-					))}
+						);
+					})}
 				</div>
 
-				<div className={`${flex({ justify: 'center' })} ${css({ mt: '12' })}`}>
+				<div className={`${flex({ justify: 'center' })} ${css({ mt: '20' })}`}>
 					<Button variant="outline" to="/offer">
-						Voir nos offres
+						Voir toutes nos interventions
 					</Button>
 				</div>
 			</Container>

--- a/components/sections/services/OffersDetailSection.tsx
+++ b/components/sections/services/OffersDetailSection.tsx
@@ -1,304 +1,277 @@
 import { CheckCircle2 } from 'lucide-react';
 import type React from 'react';
+import { Fragment } from 'react';
 import { css } from 'styled-system/css';
-import { center, flex, grid } from 'styled-system/patterns';
+import { center, flex } from 'styled-system/patterns';
+import { Badge } from '../../atoms/Badge';
 import { SectionHeader } from '../../organisms/SectionHeader';
 
-const _NewOffersDetailSection = () => {
+type ServiceColor = 'yellow' | 'sky' | 'mint';
+
+interface ServiceItem {
+	title: string;
+	description: string;
+}
+
+interface Service {
+	number: number;
+	badge: string;
+	badgeColor: ServiceColor;
+	subtitle: string;
+	title: string;
+	description: string;
+	items: ServiceItem[];
+}
+
+const SERVICES: Service[] = [
+	{
+		number: 1,
+		badge: 'DESIGN',
+		badgeColor: 'yellow',
+		subtitle: "L'architecture",
+		title: "Immersion, cadrage et plan d'action RevOps",
+		description: 'La vision claire pour savoir où agir.',
+		items: [
+			{
+				title: 'Diagnostic transversal',
+				description:
+					'Analyse en profondeur des interactions et frictions entre les départements.',
+			},
+			{
+				title: 'Cartographie process / outils / data',
+				description:
+					"Audit complet de l'infrastructure existante et des flux de travail.",
+			},
+			{
+				title: 'Priorisation et feuille de route',
+				description:
+					"Un plan d'attaque chiffré et priorisé pour les mois à venir.",
+			},
+		],
+	},
+	{
+		number: 2,
+		badge: 'OPERATE',
+		badgeColor: 'sky',
+		subtitle: 'La construction',
+		title: 'Déploiement RevOps (Agile)',
+		description:
+			'Pour opérer et structurer la machine revenue en sprints de 2 semaines.',
+		items: [
+			{
+				title: 'Architecture du Cycle Revenue',
+				description:
+					"Unifiez votre chaîne de valeur de bout en bout : de la génération de demande jusqu'à l'upsell et la facturation.",
+			},
+			{
+				title: 'Design Organisationnel',
+				description:
+					'Restructurez vos équipes (Rôles & Responsabilités) et standardisez vos process pour une exécution sans faille.',
+			},
+			{
+				title: 'Déploiement Stack & CRM',
+				description:
+					'Intégrez et connectez les leaders du marché (Salesforce, HubSpot) pour en faire de véritables moteurs de croissance.',
+			},
+			{
+				title: 'Business Intelligence',
+				description:
+					'Transformez votre donnée en tableaux de bord fiables et actionnables pour stopper le pilotage à vue.',
+			},
+			{
+				title: 'Ingénierie de la Rémunération',
+				description:
+					'Modélisez des plans de variables clairs et motivants, alignés sur vos objectifs de rentabilité.',
+			},
+		],
+	},
+	{
+		number: 3,
+		badge: 'GROW',
+		badgeColor: 'mint',
+		subtitle: 'Animation RevOps',
+		title: 'GROW (Animation RevOps)',
+		description:
+			'Pour transformer votre investissement technique en revenus récurrents et durables.',
+		items: [
+			{
+				title: 'Exploitation & Optimisation',
+				description:
+					'Tirer le meilleur parti de ce qui a été construit (Fine-tuning).',
+			},
+			{
+				title: 'Pilotage de la Donnée',
+				description:
+					'Garantir que les chiffres (Forecast, MRR, Pipeline) restent justes mois après mois.',
+			},
+			{
+				title: 'Support & Adoption',
+				description:
+					'S\'assurer que les Commerciaux utilisent vraiment les outils (Lutte contre le "Shadow IT").',
+			},
+			{
+				title: 'Évolution de la Roadmap',
+				description:
+					'Anticiper les besoins de demain pour ne jamais freiner la croissance.',
+			},
+			{
+				title: 'Acculturation RevOps pour dirigeants',
+				description:
+					'Aligner la vision stratégique et donner les clés de lecture aux décideurs.',
+			},
+		],
+	},
+];
+
+const COLOR_TOKEN_MAP: Record<ServiceColor, string> = {
+	yellow: 'ocobo.yellow',
+	sky: 'ocobo.sky',
+	mint: 'ocobo.mint',
+};
+
+const LIGHT_TOKEN_MAP: Record<ServiceColor, string> = {
+	yellow: 'ocobo.yellow.light',
+	sky: 'ocobo.sky.light',
+	mint: 'ocobo.mint.light',
+};
+
+const iconWrapperStyle = (color: ServiceColor) =>
+	css({
+		mt: '1',
+		bg: LIGHT_TOKEN_MAP[color],
+		p: '2',
+		rounded: 'full',
+		color: COLOR_TOKEN_MAP[color],
+		_groupHover: { bg: COLOR_TOKEN_MAP[color], color: 'white' },
+		transition: 'colors',
+	});
+
+const ServiceCard: React.FC<{ service: Service }> = ({ service }) => {
+	const color = service.badgeColor;
+	const colorToken = COLOR_TOKEN_MAP[color];
+
 	return (
-		<section className="py-16 md:py-24 bg-white">
-			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-				<div className="text-center mb-16 md:mb-24">
-					<h2 className="font-display text-3xl md:text-5xl font-bold text-ocobo-dark mb-4 md:mb-6">
-						Nous construisons et opérons les fondations RevOps
-					</h2>
-					<p className="text-gray-600 text-lg">
-						Nous construisons et opérons les fondations RevOps de votre
-						organisation : process, outils, data et équipes alignés pour une
-						croissance durable et maîtrisée.
+		<div
+			className={flex({
+				direction: { base: 'column', md: 'row' },
+				gap: { base: '12', md: '24' },
+				align: 'flex-start',
+			})}
+		>
+			<div
+				className={css({
+					w: { base: 'full', md: '5/12' },
+					position: { md: 'sticky' },
+					top: '32',
+				})}
+			>
+				<div
+					className={`${center()} ${css({
+						w: '16',
+						h: '16',
+						bg: colorToken,
+						color: 'ocobo.dark',
+						fontFamily: 'display',
+						fontWeight: 'bold',
+						fontSize: '2xl',
+						borderWidth: '1px',
+						borderColor: 'ocobo.dark',
+						shadow: 'offset',
+						mb: '8',
+					})}`}
+				>
+					{service.number}
+				</div>
+				<div className={css({ mb: '4' })}>
+					<Badge variant={color} rounded="full">
+						{service.badge}
+					</Badge>
+					<p
+						className={css({
+							fontSize: '2xs',
+							fontWeight: 'black',
+							textTransform: 'uppercase',
+							letterSpacing: 'widest',
+							mt: '3',
+							ml: '1',
+							opacity: '0.7',
+							color: colorToken,
+						})}
+					>
+						{service.subtitle}
 					</p>
 				</div>
-
-				<div className="space-y-24">
-					{/* Service 1: DESIGN */}
-					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
-						<div className="w-full md:w-5/12 sticky top-32">
-							<div className="w-16 h-16 bg-ocobo-yellow text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
-								1
-							</div>
-							<div className="mb-4">
-								<span className="inline-block bg-ocobo-yellow text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-									DESIGN
-								</span>
-								<p className="text-[10px] font-black text-ocobo-yellow uppercase tracking-widest mt-3 ml-1 opacity-70">
-									L'architecture
-								</p>
-							</div>
-							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
-								Immersion, cadrage et plan d’action RevOps
-							</h3>
-							<p className="text-gray-600 text-lg leading-relaxed">
-								La vision claire pour savoir où agir.
-							</p>
-						</div>
-						<div className="w-full md:w-7/12">
-							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-yellow transition-all duration-300 group rounded-xl">
-								<ul className="space-y-8">
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Diagnostic transversal
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Analyse en profondeur des interactions et frictions
-												entre les départements.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Cartographie process / outils / data
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Audit complet de l'infrastructure existante et des flux
-												de travail.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Priorisation et feuille de route
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Un plan d'attaque chiffré et priorisé pour les mois à
-												venir.
-											</p>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-
-					<div className="w-full h-px bg-gray-100"></div>
-
-					{/* Service 2: OPERATE */}
-					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
-						<div className="w-full md:w-5/12 sticky top-32">
-							<div className="w-16 h-16 bg-ocobo-sky text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
-								2
-							</div>
-							<div className="mb-4">
-								<span className="inline-block bg-ocobo-sky text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-									OPERATE
-								</span>
-								<p className="text-[10px] font-black text-ocobo-sky uppercase tracking-widest mt-3 ml-1 opacity-70">
-									La construction
-								</p>
-							</div>
-							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
-								Déploiement RevOps (Agile)
-							</h3>
-							<p className="text-gray-600 text-lg leading-relaxed">
-								Pour opérer et structurer la machine revenue en sprints de 2
-								semaines.
-							</p>
-						</div>
-						<div className="w-full md:w-7/12">
-							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-sky transition-all duration-300 group rounded-xl">
-								<ul className="space-y-8">
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Architecture du Cycle Revenue
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Unifiez votre chaîne de valeur de bout en bout : de la
-												génération de demande jusqu'à l'upsell et la
-												facturation.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Design Organisationnel
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Restructurez vos équipes (Rôles & Responsabilités) et
-												standardisez vos process pour une exécution sans faille.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Déploiement Stack & CRM
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Intégrez et connectez les leaders du marché (Salesforce,
-												HubSpot) pour en faire de véritables moteurs de
-												croissance.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Business Intelligence
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Transformez votre donnée en tableaux de bord fiables et
-												actionnables pour stopper le pilotage à vue.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Ingénierie de la Rémunération
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Modélisez des plans de variables clairs et motivants,
-												alignés sur vos objectifs de rentabilité.
-											</p>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-
-					<div className="w-full h-px bg-gray-100"></div>
-
-					{/* Service 3: GROW (UPDATED) */}
-					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
-						<div className="w-full md:w-5/12 sticky top-32">
-							<div className="w-16 h-16 bg-ocobo-mint text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
-								3
-							</div>
-							<div className="mb-4">
-								<span className="inline-block bg-ocobo-mint text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
-									GROW
-								</span>
-								<p className="text-[10px] font-black text-ocobo-mint uppercase tracking-widest mt-3 ml-1 opacity-70">
-									Animation RevOps
-								</p>
-							</div>
-							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
-								GROW (Animation RevOps)
-							</h3>
-							<p className="text-gray-600 text-lg leading-relaxed">
-								Pour transformer votre investissement technique en revenus
-								récurrents et durables.
-							</p>
-						</div>
-						<div className="w-full md:w-7/12">
-							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-mint transition-all duration-300 group rounded-xl">
-								<ul className="space-y-8">
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Exploitation & Optimisation
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Tirer le meilleur parti de ce qui a été construit
-												(Fine-tuning).
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Pilotage de la Donnée
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Garantir que les chiffres (Forecast, MRR, Pipeline)
-												restent justes mois après mois.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Support & Adoption
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												S'assurer que les Commerciaux utilisent vraiment les
-												outils (Lutte contre le "Shadow IT").
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Évolution de la Roadmap
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Anticiper les besoins de demain pour ne jamais freiner
-												la croissance.
-											</p>
-										</div>
-									</li>
-									<li className="flex gap-5 items-start">
-										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
-												Acculturation RevOps pour dirigeants
-											</h4>
-											<p className="text-sm text-gray-600 leading-relaxed">
-												Aligner la vision stratégique et donner les clés de
-												lecture aux décideurs.
-											</p>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
+				<h3
+					className={css({
+						fontFamily: 'display',
+						fontSize: { base: '3xl', md: '4xl' },
+						fontWeight: 'bold',
+						color: 'ocobo.dark',
+						mb: '4',
+						lineHeight: 'tight',
+					})}
+				>
+					{service.title}
+				</h3>
+				<p
+					className={css({
+						color: 'gray.600',
+						fontSize: 'lg',
+						lineHeight: 'relaxed',
+					})}
+				>
+					{service.description}
+				</p>
+			</div>
+			<div className={css({ w: { base: 'full', md: '7/12' } })}>
+				<div
+					className={`group ${css({
+						bg: 'white',
+						borderWidth: '1px',
+						borderColor: 'gray.100',
+						p: { base: '8', md: '10' },
+						transition: 'all',
+						transitionDuration: '300ms',
+						rounded: 'xl',
+						_hover: { shadow: '2xl', borderColor: colorToken },
+					})}`}
+				>
+					<ul className={css({ spaceY: '8' })}>
+						{service.items.map((item) => (
+							<li
+								key={item.title}
+								className={flex({ gap: '5', align: 'flex-start' })}
+							>
+								<div className={iconWrapperStyle(color)}>
+									<CheckCircle2 size={18} />
+								</div>
+								<div>
+									<h4
+										className={css({
+											fontWeight: 'bold',
+											fontSize: 'lg',
+											color: 'ocobo.dark',
+											mb: '2',
+										})}
+									>
+										{item.title}
+									</h4>
+									<p
+										className={css({
+											fontSize: 'sm',
+											color: 'gray.600',
+											lineHeight: 'relaxed',
+										})}
+									>
+										{item.description}
+									</p>
+								</div>
+							</li>
+						))}
+					</ul>
 				</div>
 			</div>
-		</section>
+		</div>
 	);
 };
 
@@ -319,524 +292,14 @@ export const OffersDetailSection: React.FC = () => {
 				/>
 
 				<div className={css({ spaceY: '24' })}>
-					{/* Service 1: Audit & Cadrage */}
-					<div
-						className={flex({
-							direction: { base: 'column', md: 'row' },
-							gap: { base: '12', md: '24' },
-							align: 'flex-start',
-						})}
-					>
-						<div
-							className={css({
-								w: { base: 'full', md: '5/12' },
-								position: { md: 'sticky' },
-								top: '32',
-							})}
-						>
-							<div
-								className={`${center()} ${css({
-									w: '16',
-									h: '16',
-									bg: 'ocobo.yellow',
-									color: 'ocobo.dark',
-									fontFamily: 'display',
-									fontWeight: 'bold',
-									fontSize: '2xl',
-									borderWidth: '1px',
-									borderColor: 'ocobo.dark',
-									shadow: 'offset',
-									mb: '8',
-								})}`}
-							>
-								1
-							</div>
-							<h3
-								className={css({
-									fontFamily: 'display',
-									fontSize: { base: '3xl', md: '4xl' },
-									fontWeight: 'bold',
-									color: 'ocobo.dark',
-									mb: '4',
-									lineHeight: 'tight',
-								})}
-							>
-								Immersion, cadrage et plan d'action RevOps
-							</h3>
-							<p
-								className={css({
-									color: 'gray.600',
-									fontSize: 'lg',
-									lineHeight: 'relaxed',
-								})}
-							>
-								La vision claire pour savoir où agir.
-							</p>
-						</div>
-						<div className={css({ w: { base: 'full', md: '7/12' } })}>
-							<div
-								className={css({
-									bg: 'white',
-									borderWidth: '1px',
-									borderColor: 'gray.100',
-									p: { base: '8', md: '10' },
-									transition: 'all',
-									transitionDuration: '300ms',
-									rounded: 'xl',
-									_hover: { shadow: '2xl', borderColor: 'ocobo.yellow' },
-								})}
-							>
-								<ul className={css({ spaceY: '8' })}>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.yellow.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.yellow',
-												_groupHover: { bg: 'ocobo.yellow', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Diagnostic transversal
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Analyse en profondeur des interactions et frictions
-												entre les départements.
-											</p>
-										</div>
-									</li>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.yellow.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.yellow',
-												_groupHover: { bg: 'ocobo.yellow', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Cartographie process / outils / data
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Audit complet de l'infrastructure existante et des flux
-												de travail.
-											</p>
-										</div>
-									</li>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.yellow.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.yellow',
-												_groupHover: { bg: 'ocobo.yellow', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Priorisation et feuille de route
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Un plan d'attaque chiffré et priorisé pour les mois à
-												venir.
-											</p>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
-
-					<div className={css({ w: 'full', h: '1px', bg: 'gray.100' })} />
-
-					{/* Service 2: Déploiement */}
-					<div
-						className={flex({
-							direction: { base: 'column', md: 'row' },
-							gap: { base: '12', md: '24' },
-							align: 'flex-start',
-						})}
-					>
-						<div
-							className={css({
-								w: { base: 'full', md: '5/12' },
-								position: { md: 'sticky' },
-								top: '32',
-							})}
-						>
-							<div
-								className={`${center()} ${css({
-									w: '16',
-									h: '16',
-									bg: 'ocobo.coral',
-									color: 'ocobo.dark',
-									fontFamily: 'display',
-									fontWeight: 'bold',
-									fontSize: '2xl',
-									borderWidth: '1px',
-									borderColor: 'ocobo.dark',
-									shadow: 'offset',
-									mb: '8',
-								})}`}
-							>
-								2
-							</div>
-							<h3
-								className={css({
-									fontFamily: 'display',
-									fontSize: { base: '3xl', md: '4xl' },
-									fontWeight: 'bold',
-									color: 'ocobo.dark',
-									mb: '4',
-									lineHeight: 'tight',
-								})}
-							>
-								Déploiement RevOps (Agile)
-							</h3>
-							<p
-								className={css({
-									color: 'gray.600',
-									fontSize: 'lg',
-									lineHeight: 'relaxed',
-								})}
-							>
-								Pour opérer et structurer la machine revenue en sprints de 2
-								semaines.
-							</p>
-						</div>
-						<div className={css({ w: { base: 'full', md: '7/12' } })}>
-							<div
-								className={css({
-									bg: 'white',
-									borderWidth: '1px',
-									borderColor: 'gray.100',
-									p: { base: '8', md: '10' },
-									transition: 'all',
-									transitionDuration: '300ms',
-									rounded: 'xl',
-									_hover: { shadow: '2xl', borderColor: 'ocobo.coral' },
-								})}
-							>
-								<ul
-									className={grid({
-										columns: { md: 2 },
-										gap: 6,
-										rowGap: 6,
-										columnGap: 8,
-									})}
-								>
-									{[
-										'Funnel complet : demand gen → closing → onboarding → expansion',
-										'Process simples & adoptés',
-										'CRM utile et utilisé',
-										'Stack lisible et connectée',
-										'Automatisations utiles',
-										'Data fiable & pilotable',
-										'Rémunération variable claire, juste et motivante',
-									].map((item) => (
-										<li
-											key={item}
-											className={flex({ align: 'flex-start', gap: '4' })}
-										>
-											<div className={css({ mt: '0.5', color: 'ocobo.coral' })}>
-												<CheckCircle2 size={18} />
-											</div>
-											<span
-												className={css({
-													fontWeight: 'medium',
-													color: 'gray.700',
-													fontSize: 'sm',
-													lineHeight: 'snug',
-												})}
-											>
-												{item}
-											</span>
-										</li>
-									))}
-								</ul>
-							</div>
-						</div>
-					</div>
-
-					<div className={css({ w: 'full', h: '1px', bg: 'gray.100' })} />
-
-					{/* Service 3: Coaching */}
-					<div
-						className={flex({
-							direction: { base: 'column', md: 'row' },
-							gap: { base: '12', md: '24' },
-							align: 'flex-start',
-						})}
-					>
-						<div
-							className={css({
-								w: { base: 'full', md: '5/12' },
-								position: { md: 'sticky' },
-								top: '32',
-							})}
-						>
-							<div
-								className={`${center()} ${css({
-									w: '16',
-									h: '16',
-									bg: 'ocobo.mint',
-									color: 'ocobo.dark',
-									fontFamily: 'display',
-									fontWeight: 'bold',
-									fontSize: '2xl',
-									borderWidth: '1px',
-									borderColor: 'ocobo.dark',
-									shadow: 'offset',
-									mb: '8',
-								})}`}
-							>
-								3
-							</div>
-							<h3
-								className={css({
-									fontFamily: 'display',
-									fontSize: { base: '3xl', md: '4xl' },
-									fontWeight: 'bold',
-									color: 'ocobo.dark',
-									mb: '4',
-									lineHeight: 'tight',
-								})}
-							>
-								Coaching & Formation
-							</h3>
-							<p
-								className={css({
-									color: 'gray.600',
-									fontSize: 'lg',
-									lineHeight: 'relaxed',
-								})}
-							>
-								Rendre vos équipes autonomes et capables de faire vivre le
-								système.
-							</p>
-						</div>
-						<div className={css({ w: { base: 'full', md: '7/12' } })}>
-							<div
-								className={css({
-									bg: 'white',
-									borderWidth: '1px',
-									borderColor: 'gray.100',
-									p: { base: '8', md: '10' },
-									transition: 'all',
-									transitionDuration: '300ms',
-									rounded: 'xl',
-									_hover: { shadow: '2xl', borderColor: 'ocobo.mint' },
-								})}
-							>
-								<ul className={css({ spaceY: '8' })}>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.mint.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.mint',
-												_groupHover: { bg: 'ocobo.mint', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Acculturation RevOps pour dirigeants
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Aligner la vision stratégique et donner les clés de
-												lecture aux décideurs.
-											</p>
-										</div>
-									</li>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.mint.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.mint',
-												_groupHover: { bg: 'ocobo.mint', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Coaching Heads (Sales / CS / RevOps)
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Accompagnement individuel des responsables pour piloter
-												l'excellence opérationnelle.
-											</p>
-										</div>
-									</li>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.mint.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.mint',
-												_groupHover: { bg: 'ocobo.mint', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Montée en compétence des équipes
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Formation pratique aux nouveaux rituels, outils et
-												méthodes GTM.
-											</p>
-										</div>
-									</li>
-									<li className={flex({ gap: '5', align: 'flex-start' })}>
-										<div
-											className={css({
-												mt: '1',
-												bg: 'ocobo.mint.light',
-												p: '2',
-												rounded: 'full',
-												color: 'ocobo.mint',
-												_groupHover: { bg: 'ocobo.mint', color: 'white' },
-												transition: 'colors',
-											})}
-										>
-											<CheckCircle2 size={18} />
-										</div>
-										<div>
-											<h4
-												className={css({
-													fontWeight: 'bold',
-													fontSize: 'lg',
-													color: 'ocobo.dark',
-													mb: '2',
-												})}
-											>
-												Playbooks pratiques
-											</h4>
-											<p
-												className={css({
-													fontSize: 'sm',
-													color: 'gray.600',
-													lineHeight: 'relaxed',
-												})}
-											>
-												Création de bibles opérationnelles pour ancrer
-												durablement les process.
-											</p>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
-					</div>
+					{SERVICES.map((service, i) => (
+						<Fragment key={service.number}>
+							{i > 0 && (
+								<div className={css({ w: 'full', h: '1px', bg: 'gray.100' })} />
+							)}
+							<ServiceCard service={service} />
+						</Fragment>
+					))}
 				</div>
 			</div>
 		</section>

--- a/components/sections/services/OffersDetailSection.tsx
+++ b/components/sections/services/OffersDetailSection.tsx
@@ -4,6 +4,304 @@ import { css } from 'styled-system/css';
 import { center, flex, grid } from 'styled-system/patterns';
 import { SectionHeader } from '../../organisms/SectionHeader';
 
+const _NewOffersDetailSection = () => {
+	return (
+		<section className="py-16 md:py-24 bg-white">
+			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+				<div className="text-center mb-16 md:mb-24">
+					<h2 className="font-display text-3xl md:text-5xl font-bold text-ocobo-dark mb-4 md:mb-6">
+						Nous construisons et opérons les fondations RevOps
+					</h2>
+					<p className="text-gray-600 text-lg">
+						Nous construisons et opérons les fondations RevOps de votre
+						organisation : process, outils, data et équipes alignés pour une
+						croissance durable et maîtrisée.
+					</p>
+				</div>
+
+				<div className="space-y-24">
+					{/* Service 1: DESIGN */}
+					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
+						<div className="w-full md:w-5/12 sticky top-32">
+							<div className="w-16 h-16 bg-ocobo-yellow text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
+								1
+							</div>
+							<div className="mb-4">
+								<span className="inline-block bg-ocobo-yellow text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+									DESIGN
+								</span>
+								<p className="text-[10px] font-black text-ocobo-yellow uppercase tracking-widest mt-3 ml-1 opacity-70">
+									L'architecture
+								</p>
+							</div>
+							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
+								Immersion, cadrage et plan d’action RevOps
+							</h3>
+							<p className="text-gray-600 text-lg leading-relaxed">
+								La vision claire pour savoir où agir.
+							</p>
+						</div>
+						<div className="w-full md:w-7/12">
+							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-yellow transition-all duration-300 group rounded-xl">
+								<ul className="space-y-8">
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Diagnostic transversal
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Analyse en profondeur des interactions et frictions
+												entre les départements.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Cartographie process / outils / data
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Audit complet de l'infrastructure existante et des flux
+												de travail.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-yellowLight p-2 rounded-full text-ocobo-yellow group-hover:bg-ocobo-yellow group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Priorisation et feuille de route
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Un plan d'attaque chiffré et priorisé pour les mois à
+												venir.
+											</p>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+
+					<div className="w-full h-px bg-gray-100"></div>
+
+					{/* Service 2: OPERATE */}
+					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
+						<div className="w-full md:w-5/12 sticky top-32">
+							<div className="w-16 h-16 bg-ocobo-sky text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
+								2
+							</div>
+							<div className="mb-4">
+								<span className="inline-block bg-ocobo-sky text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+									OPERATE
+								</span>
+								<p className="text-[10px] font-black text-ocobo-sky uppercase tracking-widest mt-3 ml-1 opacity-70">
+									La construction
+								</p>
+							</div>
+							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
+								Déploiement RevOps (Agile)
+							</h3>
+							<p className="text-gray-600 text-lg leading-relaxed">
+								Pour opérer et structurer la machine revenue en sprints de 2
+								semaines.
+							</p>
+						</div>
+						<div className="w-full md:w-7/12">
+							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-sky transition-all duration-300 group rounded-xl">
+								<ul className="space-y-8">
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Architecture du Cycle Revenue
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Unifiez votre chaîne de valeur de bout en bout : de la
+												génération de demande jusqu'à l'upsell et la
+												facturation.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Design Organisationnel
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Restructurez vos équipes (Rôles & Responsabilités) et
+												standardisez vos process pour une exécution sans faille.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Déploiement Stack & CRM
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Intégrez et connectez les leaders du marché (Salesforce,
+												HubSpot) pour en faire de véritables moteurs de
+												croissance.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Business Intelligence
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Transformez votre donnée en tableaux de bord fiables et
+												actionnables pour stopper le pilotage à vue.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-skyLight p-2 rounded-full text-ocobo-sky group-hover:bg-ocobo-sky group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Ingénierie de la Rémunération
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Modélisez des plans de variables clairs et motivants,
+												alignés sur vos objectifs de rentabilité.
+											</p>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+
+					<div className="w-full h-px bg-gray-100"></div>
+
+					{/* Service 3: GROW (UPDATED) */}
+					<div className="flex flex-col md:flex-row gap-12 md:gap-24 items-start">
+						<div className="w-full md:w-5/12 sticky top-32">
+							<div className="w-16 h-16 bg-ocobo-mint text-ocobo-dark flex items-center justify-center font-display font-bold text-2xl border border-ocobo-dark shadow-[4px_4px_0px_0px_rgba(33,35,35,1)] mb-8">
+								3
+							</div>
+							<div className="mb-4">
+								<span className="inline-block bg-ocobo-mint text-ocobo-dark px-6 py-2 rounded-full font-display font-black text-xs uppercase tracking-[0.25em] shadow-sm">
+									GROW
+								</span>
+								<p className="text-[10px] font-black text-ocobo-mint uppercase tracking-widest mt-3 ml-1 opacity-70">
+									Animation RevOps
+								</p>
+							</div>
+							<h3 className="font-display text-3xl md:text-4xl font-bold text-ocobo-dark mb-4 leading-tight">
+								GROW (Animation RevOps)
+							</h3>
+							<p className="text-gray-600 text-lg leading-relaxed">
+								Pour transformer votre investissement technique en revenus
+								récurrents et durables.
+							</p>
+						</div>
+						<div className="w-full md:w-7/12">
+							<div className="bg-white border border-gray-100 p-8 md:p-10 hover:shadow-2xl hover:border-ocobo-mint transition-all duration-300 group rounded-xl">
+								<ul className="space-y-8">
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Exploitation & Optimisation
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Tirer le meilleur parti de ce qui a été construit
+												(Fine-tuning).
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Pilotage de la Donnée
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Garantir que les chiffres (Forecast, MRR, Pipeline)
+												restent justes mois après mois.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Support & Adoption
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												S'assurer que les Commerciaux utilisent vraiment les
+												outils (Lutte contre le "Shadow IT").
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Évolution de la Roadmap
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Anticiper les besoins de demain pour ne jamais freiner
+												la croissance.
+											</p>
+										</div>
+									</li>
+									<li className="flex gap-5 items-start">
+										<div className="mt-1 bg-ocobo-mintLight p-2 rounded-full text-ocobo-mint group-hover:bg-ocobo-mint group-hover:text-white transition-colors">
+											<CheckCircle2 size={18} />
+										</div>
+										<div>
+											<h4 className="font-bold text-lg text-ocobo-dark mb-2">
+												Acculturation RevOps pour dirigeants
+											</h4>
+											<p className="text-sm text-gray-600 leading-relaxed">
+												Aligner la vision stratégique et donner les clés de
+												lecture aux décideurs.
+											</p>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+};
+
 export const OffersDetailSection: React.FC = () => {
 	return (
 		<section className={css({ py: { base: '16', md: '24' }, bg: 'white' })}>


### PR DESCRIPTION
## Summary
- Migrate `InterventionsSection` from Tailwind studio markup to Panda CSS with data-driven cards, Badge pills, subtitle labels, and hover-reveal footers
- Migrate `OffersDetailSection` to Panda CSS with Badge + subtitle per service, OPERATE colour changed to sky, service 3 renamed to GROW (Animation RevOps) with updated items
- Delete old `_New*` prefixed components and `INTERVENTIONS` data array

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm test` passes
- [ ] Visual check: homepage interventions section
- [ ] Visual check: `/offer` page detail section

🤖 Generated with [Claude Code](https://claude.com/claude-code)